### PR TITLE
修改联系方式中的微信群联系方式为qq群联系方式，防止微信群二维码过期

### DIFF
--- a/product/计算与网络/无服务器云函数/联系我们.md
+++ b/product/计算与网络/无服务器云函数/联系我们.md
@@ -1,5 +1,5 @@
 您有任何对于 SCF 产品的反馈或者希望能够与工程师即时沟通，欢迎通过以下方式联系我们：
 
 - 腾讯云论坛：http://bbs.qcloud.com/forum.php
-- SCF 微信用户群：
-![](//mc.qcloudimg.com/static/img/69c59c2a942ea9b55fdec2a265d39ac0/image.jpg)
+- SCF QQ 用户群
+![](https://mc.qcloudimg.com/static/img/76af3658e287914466c90b6281928a30/image.png)


### PR DESCRIPTION
rtx：alfredhuang