### PR TITLE
remove trailing escape letter in cli example

### DIFF
--- a/product/监控与管理/命令行工具/快速入门/快速使用命令行工具.md
+++ b/product/监控与管理/命令行工具/快速入门/快速使用命令行工具.md
@@ -15,7 +15,7 @@ qcloudcli <command> <operation> [options and parameters]
 下面使用一个示例来简单说明：
 
 ```
-$ qcloudcli cvm DescribeInstances --status 3 --output table\
+$ qcloudcli cvm DescribeInstances --status 3 --output table
 ```
 此命令以 `table` 格式输出 `默认账户` 的 `状态为3` 的 CVM 实例信息。其中：
 


### PR DESCRIPTION
There is an unexpected trailing escape letter '\' in the example
for quick introduce to qcloudcli, it will cause error in windows
platform and expect additional input in linux operating system.

This patch removes the unnecessary letter.