### PR TITLE
服务限流 SDK 使用文档

### DIFF
--- a/product/互联网中间件/腾讯分布式服务框架/开发手册/Spring Cloud 应用接入/服务限流.md
+++ b/product/互联网中间件/腾讯分布式服务框架/开发手册/Spring Cloud 应用接入/服务限流.md
@@ -1,0 +1,36 @@
+## 一、准备工作
+
+TODO: 写上限流相关的文档。下面是从鉴权文档中拷贝过来的。
+
+> 开始实践服务鉴权功能前，请确保已完成了 [准备工作](https://cloud.tencent.com/document/product/649/16619)，并阅读 [服务鉴权概述](https://cloud.tencent.com/document/product/649/18024)。
+
+## 二、快速上手
+
+如果你要对某个服务开启限流的能力，即对调用它的请求做限流，可以按下面的步骤打开限流开关。
+
+先向工程中添加依赖。在 `pom.xml` 中添加：
+
+```xml
+<dependency>
+    <groupId>com.tencent.tsf</groupId>
+    <artifactId>spring-cloud-tsf-ratelimit</artifactId>
+    <version>1.1.1-RELEASE</version>
+</dependency>
+```
+
+然后向 Application 类中添加注解 `@EnableTsfRateLimit`：
+
+```java
+// 下面省略了无关的代码
+import org.springframework.tsf.ratelimit.annotation.EnableTsfRateLimit;
+
+@SpringBootApplication
+@EnableTsfRateLimit
+public class ProviderApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(ProviderApplication.class, args);
+	}
+}
+```
+
+此时你已经对服务开启了限流功能，任何到达的请求都会被限流模块处理。如果该服务上的配额已经消耗完，会对请求返回 HTTP 429 Too Many Requests；否则会正常放行。


### PR DESCRIPTION
服务限流 SDK 比较简单。

有些相关文档的链接仍需要补充下，比如控制台的使用等。