### PR TITLE
更改filterType

### DIFF
--- a/api/计算与网络/消息队列/主题模型/主题相关接口/获取主题属性.md
+++ b/api/计算与网络/消息队列/主题模型/主题相关接口/获取主题属性.md
@@ -30,7 +30,7 @@
 | msgRetentionSeconds| Int| 消息在主题中最长存活时间，从发送到该主题开始经过此参数指定的时间后，不论消息是否被成功推送给用户都将被删除，单位为秒。固定为一天（86400秒），该属性不能修改|
 | createTime| Int| 主题的创建时间。返回 Unix 时间戳，精确到秒|
 | lastModifyTime| Int| 最后一次修改主题属性的时间。返回 Unix 时间戳，精确到秒。|
-|filterType|Int|描述用户创建订阅时选择的过滤策略：<br>filterType = 0表示用户使用 filterTag 标签过滤<br>filterType = 1表示用户使用  bindingKey 过滤|
+|filterType|Int|描述用户创建订阅时选择的过滤策略：<br>filterType = 1表示用户使用 filterTag 标签过滤<br>filterType = 2表示用户使用  bindingKey 过滤|
 
 ## 示例
 


### PR DESCRIPTION
修复 
filterType =1 或为空， 表示该主题下所有订阅使用 filterTag 标签过滤；
filterType =2 表示用户使用 bindingKey 过滤。
注意：该参数设定之后不可更改。