### PR TITLE
更新制作容器镜像指南

### DIFF
--- a/product/互联网中间件/腾讯分布式服务框架/开发手册/制作容器镜像.md
+++ b/product/互联网中间件/腾讯分布式服务框架/开发手册/制作容器镜像.md
@@ -13,11 +13,12 @@ RUN yum update -y && yum install -y java-1.8.0-openjdk
 # 设置时区。这对于日志、调用链等功能能否在 TSF 控制台被检索到非常重要。
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 RUN echo "Asia/Shanghai" > /etc/timezone
-# Java 程序及起始路径设为 /data/tsf_default/，是使用「默认日志配置项」的必要条件。
-ENV workdir /data/tsf_default/
+
+ENV workdir /app/
 ENV jar provider-demo-0.0.1-SNAPSHOT.jar
 COPY ${jar} ${workdir}
 WORKDIR ${workdir}
+
 # JAVA_OPTS 环境变量的值为部署组的 JVM 启动参数，在运行时 bash 替换。使用 exec 以使 Java 程序可以接收 SIGTERM 信号。
 CMD ["sh", "-ec", "exec java ${JAVA_OPTS} -jar ${jar}"]
 ```


### PR DESCRIPTION
由于容器部署组不支持「默认日志配置项」，去掉相关指引避免混淆。

@alonsolu001 