### PR TITLE
Update 使用腾讯云软件源加速软件包下载和更新 中的 pip 的配置方式

### DIFF
--- a/product/计算与网络/云服务器/运维指南/Linux 运维/软件安装/使用腾讯云软件源加速软件包下载和更新.md
+++ b/product/计算与网络/云服务器/运维指南/Linux 运维/软件安装/使用腾讯云软件源加速软件包下载和更新.md
@@ -22,16 +22,29 @@ http://mirrors.tencentyun.com/
 
 运行以下命令以使用腾讯云pypi软件源：
 ```
-pip install -i http://mirrors.tencentyun.com/pypi/simple <some-package>
+pip install -i https://mirrors.tencentyun.com/pypi/simple <some-package>
 ```
 注意：必须加上路径中的`simple`
 
 ### 设为默认
+
 修改 `~/.pip/pip.conf` (没有就创建一个)文件，更新`index-url`至腾讯云路径，如：
 ```
 [global]
-index-url = http://mirrors.tencentyun.com/pypi/simple
+index-url = https://mirrors.tencentyun.com/pypi/simple
 trusted-host = mirrors.tencentyun.com
+```
+也可以升级 pip 到最新的版本 (>=10.0.0) 后进行配置：
+
+```
+pip install pip -U
+pip config set global.index-url https://mirrors.tencentyun.com/pypi/simple
+```
+如果您到 pip 默认源的网络连接较差，临时使用本镜像站来升级 pip：
+
+```
+pip install -i https://mirrors.tencentyun.com/pypi/simple pip -U
+
 ```
 ### 同步周期
 腾讯云每天从`pypi.python.org`官方同步一次。


### PR DESCRIPTION
1. 都 9012 年了，我们应该使用 https啦 ~\(≧▽≦)/~啦啦啦
2. *也可以升级 pip 到最新的版本 (>=10.0.0) 后进行配置*，引用自[ 清华大学开源软件镜像站 - pypi 镜像使用帮助](https://mirrors.tuna.tsinghua.edu.cn/help/pypi/)