### PR TITLE
修改Ckafka v2 API示例 将之前的CVM更改为Ckafka接口

### DIFF
--- a/api/计算与网络/CKafka/调用方式/请求签名.md
+++ b/api/计算与网络/CKafka/调用方式/请求签名.md
@@ -31,38 +31,35 @@ SecretKey： Gu5t9xGARNpq86cd98joQYCN3Cozk1qA
 
 >!这里只是示例，请用户根据自己实际的 SecretId 和 SecretKey 和请求参数进行后续操作。
 
-以腾讯云 CVM 为例，当用户调用腾讯云 CVM 的 [查看实例列表](https://cloud.tencent.com/document/product/213/9388)（DescribeInstances）接口时，其请求参数为：
+以腾讯云 Ckafka 接口为例，当用户调用腾讯云 Ckafka 的 [查看实例列表](https://cloud.tencent.com/document/product/597/10085)（ListInstances）接口时，其请求参数为：
 
 | 参数名称 | 描述 | 参数值| 
 |---------|---------|---------|
-| Action | 方法名| DescribeInstances | 
+| Action | 方法名| ListInstances | 
 | SecretId | 密钥 ID | AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA | 
 | Timestamp | 当前时间戳 | 1465185768 | 
 | Nonce | 随机正整数 | 11886 | 
 | Region | 实例所在区域 | ap-guangzhou | 
 | SignatureMethod | 签名方式 | HmacSHA256 | 
-| InstanceIds.0 | 待查询的实例 ID | ins-09dx96dg | 
 
 ### 1. 对参数排序
 首先对所有请求参数按参数名做字典序升序排列。（所谓字典序升序排列，直观上就如同在字典中排列单词一样排序，按照字母表或数字表里递增顺序的排列次序，即先考虑第一个“字母”，在相同的情况下考虑第二个“字母”，依此类推。）您可以借助编程语言中的相关排序函数来实现这一功能，如 PHP 中的 ksort 函数。上述示例参数的排序结果如下：
 
 ```shell
 {
-"Action" : "DescribeInstances",
-"InstanceIds.0" : "ins-09dx96dg",
+"Action" : "ListInstances",
 "Nonce" : "11886",
 "Region" : "ap-guangzhou",
 "SecretId" : "AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA",
 "SignatureMethod" : "HmacSHA256",
 "Timestamp" : "1465185768"
-
 }
 ```
 使用其它程序设计语言开发时, 可对上面示例中的参数进行排序，得到的结果一致即可。
 
 ### 2. 拼接请求字符串
 此步骤将生成请求字符串。
-将把上一步排序好的请求参数格式化成`“参数名称”=“参数值”`的形式，如对 Action 参数，其参数名称为`"Action"`，参数值为`"DescribeInstances"`，因此格式化后就为 `Action=DescribeInstances`。
+将把上一步排序好的请求参数格式化成`“参数名称”=“参数值”`的形式，如对 Action 参数，其参数名称为`"Action"`，参数值为`"ListInstances"`，因此格式化后就为 `Action=ListInstances`。
 
 >!
 - “参数值”为原始值而非 URL 编码后的值。
@@ -71,8 +68,7 @@ SecretKey： Gu5t9xGARNpq86cd98joQYCN3Cozk1qA
 然后将格式化后的各个参数用`"&"`拼接在一起，最终生成的请求字符串为（请忽略文中的换行）：
 
 ```shell
-Action=DescribeInstances
-&InstanceIds.0=ins-09dx96dg
+Action=ListInstances
 &Nonce=11886
 &Region=ap-guangzhou
 &SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA
@@ -86,15 +82,14 @@ Action=DescribeInstances
 
 参数构成说明：
 * **请求方法：** 支持 POST 和 GET 方式，这里使用 GET 请求， 注意方法为全大写。
-* **请求主机：**即主机域名，请求域名由接口所属的产品或所属产品的模块决定，不同产品或不同产品的模块的请求域名会有不同。如腾讯云 CVM 的查询实例列表（DescribeInstances）的请求域名为：`cvm.api.qcloud.com`，具体产品请求域名详见各接口说明。
-* **请求路径：** 腾讯云 API 对应产品的请求路径，一般是一个产品对应一个固定路径，如腾讯云 CVM 请求路径固定为`/v2/index.php`。
+* **请求主机：**即主机域名，请求域名由接口所属的产品或所属产品的模块决定，不同产品或不同产品的模块的请求域名会有不同。如腾讯云 CVM 的查询实例列表（ListInstances）的请求域名为：`ckafka.api.qcloud.com`，具体产品请求域名详见各接口说明。
+* **请求路径：** 腾讯云 API 对应产品的请求路径，一般是一个产品对应一个固定路径，如腾讯云 Ckafka 请求路径固定为`/v2/index.php`。
 * **请求字符串：** 即上一步生成的请求字符串。
 
 
 因此，上述示例的拼接签名原文字符串结果为（请忽略文中的换行）：
 ```shell
-GETcvm.api.qcloud.com/v2/index.php?Action=DescribeInstances
-&InstanceIds.0=ins-09dx96dg
+GETckafka.api.qcloud.com/v2/index.php?Action=ListInstances
 &Nonce=11886
 &Region=ap-guangzhou
 &SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA
@@ -112,7 +107,7 @@ GETcvm.api.qcloud.com/v2/index.php?Action=DescribeInstances
 
 ```php
 $secretKey = 'Gu5t9xGARNpq86cd98joQYCN3Cozk1qA';
-$srcStr = 'GETcvm.api.qcloud.com/v2/index.php?Action=DescribeInstances&InstanceIds.0=ins-09dx96dg&Nonce=11886&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA&SignatureMethod=HmacSHA256&Timestamp=1465185768';
+$srcStr = 'GETckafka.api.qcloud.com/v2/index.php?Action=ListInstances&Nonce=11886&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA&SignatureMethod=HmacSHA256&Timestamp=1465185768';
 $signStr = base64_encode(hash_hmac('sha256', $srcStr, $secretKey, true));
 echo $signStr;
 ```
@@ -125,7 +120,7 @@ echo $signStr;
 同理，当您指定签名算法为 **HmacSHA1** 时，生成签名串的代码如下：
 ```php
 $secretKey = 'Gu5t9xGARNpq86cd98joQYCN3Cozk1qA';
-$srcStr = 'GETcvm.api.qcloud.com/v2/index.php?Action=DescribeInstances&InstanceIds.0=ins-09dx96dg&Nonce=11886&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA&SignatureMethod=HmacSHA1&Timestamp=1465185768';
+$srcStr = 'GETcckafka.api.qcloud.com/v2/index.php?Action=ListInstances&Nonce=11886&Region=ap-guangzhou&SecretId=AKIDz8krbsJ5yKBZQpn74WFkmLPx3gnPhESA&SignatureMethod=HmacSHA1&Timestamp=1465185768';
 $signStr = base64_encode(hash_hmac('sha1', $srcStr, $secretKey, true));
 echo $signStr;
 ```

--- a/api/计算与网络/CKafka/调用方式/请求结构/接口请求参数.md
+++ b/api/计算与网络/CKafka/调用方式/请求结构/接口请求参数.md
@@ -1,21 +1,19 @@
 一个完整的腾讯云 API 请求需要两类请求参数：公共请求参数和接口请求参数。本文将介绍腾讯云 API 请求需要用到的接口请求参数，有关公共请求参数的详细说明请参见 [公共请求参数](https://cloud.tencent.com/document/product/597/10084) 章节。
 接口请求参数与具体的接口有关，不同的接口支持的接口请求参数也不一样。接口请求参数的首字母均为小写，以此区分于公共请求参数。
 
->! 文章中的参数以腾讯云 CVM 为例，各腾讯云产品的实际参数请对应实际产品 API 参数说明。
+>! 文章中的参数以腾讯云 Ckafka 为例，各腾讯云产品的实际参数请对应实际产品 API 参数说明。
 
-以下参数列表以腾讯云 CVM [查询实例列表](https://cloud.tencent.com/document/api/229/831) 接口（DescribeInstances）为例，该 API 支持的接口请求参数如下：
+以下参数列表以腾讯云 Ckafka [查询实例列表](https://cloud.tencent.com/document/product/597/10093) 接口（ListInstances）为例，该 API 支持的接口请求参数如下：
 
 | 参数名称 |   描述 | 类型 |必选  |
 |---------|---------|---------|---------|
-| instanceIds.n  |要查询的 CVM 实例 ID 数组，数组下标从0开始。可以使用 instanceId 和 unInstanceId，建议使用统一资源 ID：unInstanceId。| String |否 |  
-| lanIps.n | 要查询的云服务器的内网 IP 数组。 | String | 否 | 
-| searchWord | 用户设定的主机别名。| String | 否 |
+| instanceId  |（过滤条件）按照实例ID过滤。| String |否 |  
+| searchWord | （过滤条件）按照实例名称过滤，支持模糊查询。| String | 否 |
+| status | （过滤条件）实例的状态。0：创建中，1：运行中，2：删除中，不填默认返回全部。| Int | 否 |
 | offset |记录开始的偏移，第一条记录为0，以此类推。 |   Int | 否 |
-| limit | 一次最多可查询的服务器数量，默认为20，最大为100。|Int | 否 | 
-| status | 待查询的主机状态。| Int | 否 |
-| projectId |  项目 ID，不传则查询全部项目的 CVM 实例。0表示默认项目，如需指定其他项目，可调用 [查询项目列表](https://cloud.tencent.com/document/product/378/4400)（DescribeProject）接口查询。| String |否 |
-| simplify | 获取非实时数据，当传参添加 simplify=1 时获取非实时数据。| Int | 否 |
-| zoneId |可用区 ID，不传则查询所有可用区的 CVM 实例。如需指定可用区，可调用 [查询可用区列表](https://cloud.tencent.com/document/product/213/15707)（DescribeZones）接口查询。|  Int | 否 |
+| limit | 一次最多可查询的服务器数量，默认为10，最大为20。|Int | 否 | 
+| tagKey | 匹配标签key值。|String | 否 | 
+
 
 其中各字段的说明如下：
 
@@ -25,15 +23,13 @@
 **描述：**简要描述了此接口请求参数的内容。
 
 ### 使用示例
-腾讯各云产品 API 请求链接中，接口请求参数的形式如下，以腾讯云 CVM 为例，假设用户想要查询伸缩组列表，则其请求链接的形式为：
+腾讯各云产品 API 请求链接中，接口请求参数的形式如下，以腾讯云 Ckafka 为例，假设用户想要查询伸缩组列表，则其请求链接的形式为：
 <pre>
-https://cvm.api.qcloud.com/v2/index.php?
+https://ckafka.api.qcloud.com/v2/index.php?
 &<<a href="https://cloud.tencent.com/document/api/213/6976">公共请求参数</a>>
-&instanceIds.0=ins-0hm4gvho
-&instanceIds.1=ins-8oby8q00
+&instanceId=ckafka-0hm4gvho
 &offset=0
 &limit=20
-&status=2
-&zoneId=100003
+&status=1
 </pre>
 


### PR DESCRIPTION
修改Ckafka v2 API 示例 ， 将之前的以CVM为例改成了以Ckafka的接口为例