### PR TITLE
更正 文档 中的 android.hardware.Camera

### DIFF
--- a/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Android).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Android).md
@@ -106,7 +106,7 @@ defaultConfig {
 <uses-permission android:name="android.permission.BLUETOOTH" />
 <uses-permission android:name="android.permission.CAMERA" />
 <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-<uses-feature android:name="android.hardware.Camera"/>
+<uses-feature android:name="android.hardware.camera"/>
 <uses-feature android:name="android.hardware.camera.autofocus" />
 ```
 


### PR DESCRIPTION
只有 android.hardware.camera，没有 android.hardware.Camera
可以不写，android.permission.CAMERA 会隐式添加 android.hardware.camera。

但是，写错了，就会导致 Google Play 等以 features 方式分发的商店无法使用。
毕竟，真的没有哪个设备有 android.hardware.Camera 这个 feature。