### PR TITLE
Fix(Serverless Framework/快速部署 Koa 框架.md): 修复错误的文件名

### DIFF
--- a/product/计算与网络/Serverless Framework/最佳实践/Node.js 框架支持/快速部署 Koa 框架.md
+++ b/product/计算与网络/Serverless Framework/最佳实践/Node.js 框架支持/快速部署 Koa 框架.md
@@ -24,11 +24,11 @@ $ touch serverless.yml
 npm init              # 创建后持续回车
 npm i --save koa  # 安装 koa
 ```
-3.本地创建一个 `app.js` 文件：
+3.本地创建一个 `sls.js` 文件：
 ```console
-$ touch app.js
+$ touch sls.js
 ```
-4.在 `app.js` 文件中创建您的 Koa App：
+4.在 `sls.js` 文件中创建您的 Koa App：
 ```js
 const koa = require('koa')
 const app = new koa()
@@ -59,7 +59,7 @@ name: koaDemo # (required) name of your koa component instance.
 
 inputs:
   src:
-    src: ./src # (optional) path to the source folder. default is a hello world app.
+    src: ./ # (optional) path to the source folder. default is a hello world app.
     exclude:
       - .env
   region: ap-guangzhou


### PR DESCRIPTION
原文档使用的 `app.js` 文件在部署时没有被云函数调用，应为 `sls.js`，具体代码参见云函数中 `_shims/handler.js` 以下：
  const userSls = path.join(__dirname, '..', 'sls.js')
  let app
  if (fs.existsSync(userSls)) {
    // load the user provided app
    app = require(userSls)
  } else {
    // load the built-in default app
    app = require('./sls.js')
  }
同时，在 `serverless.yml` 的 `src` 配置项中应为 `./`，使用 `./src` 和本文档是冲突的，会提示 not found