### PR TITLE
Update 应用高可用部署.md

### DIFF
--- a/product/计算与网络/容器服务/最佳实践/服务部署/应用高可用部署.md
+++ b/product/计算与网络/容器服务/最佳实践/服务部署/应用高可用部署.md
@@ -45,6 +45,7 @@ affinity:
 3. 为这一批次的节点打上相同 label 进行标识，这些节点是置放群组中某个同一批次添加的节点:
 <img style="width:450px" src="https://main.qcloudimg.com/raw/276684c8f448e70a366a2981408ac54b.png" data-nonescope="true">
 4. 节点创建好后，给要部署的工作负载的 Pod 指定节点亲和性，指定部署在这一批节点上，同时也指定 Pod 反亲和，将 Pod 在这批节点中尽量打散调度，示例:
+
 ```
 affinity:
   nodeAffinity:

--- a/product/计算与网络/容器服务/最佳实践/服务部署/应用高可用部署.md
+++ b/product/计算与网络/容器服务/最佳实践/服务部署/应用高可用部署.md
@@ -1,10 +1,10 @@
-
 高可用性（High Availability，HA）是指应用系统无中断运行的能力，通常可通过提高该系统的容错能力来实现。一般情况下，通过设置 `replicas` 给应用创建多个副本，可以适当提高应用容错能力，但这并不意味着应用就此实现高可用性。
 本文为部署应用高可用的最佳实践，通过以下四种方式实现高可用性。您可结合实际情况，选择多种方式进行部署：
+
 - [使用反亲和性避免单点故障](#PodAntiAffinity)
+- [使用置放群组从物理层面做容灾](#PlacementSet)
 - [使用 PodDisruptionBudget 避免驱逐导致服务不可用](#PodDisruptionBudget)
 - [使用 preStopHook 和 readinessProbe 保证服务平滑更新不中断](#update)
-- [解决长连接服务扩容失效](#lapse)
 
 
 ## 使用反亲和性避免单点故障<span ID="PodAntiAffinity"></span>
@@ -28,14 +28,47 @@ affinity:
  - **requiredDuringSchedulingIgnoredDuringExecution**
 此为反亲和性硬性条件，强调 Pod 调度时必须要满足该条件。当不存在满足该条件的节点时，Pod 将不会调度到任何节点（Pending）。
 如果不使用这种硬性条件，也可以使用 `preferredDuringSchedulingIgnoredDuringExecution` 来指示调度器尽量满足反亲和性条件。当不存在满足该条件的节点时，Pod 也可以调度到某个节点。
-
 - **labelSelector.matchExpressions**
 标记该服务对应 Pod 中 labels 的 key 与 values。
-
 - **topologyKey**
-本示例中使用 `kubernetes.io/hostname`，表示避免 Pod 调度到同一节点。
-如果您有更高的要求，例如避免调度到同一个可用区的节点，实现异地多活，则可以使用 `failure-domain.beta.kubernetes.io/zone`。
-但通常情况下，同一个集群的节点都在一个地域，如果节点跨地域，即使使用专线，时延也会很大。如果无法避免调度到同一个地域的节点，则可以使用 `failure-domain.beta.kubernetes.io/region`。
+  本示例中使用 `kubernetes.io/hostname`，表示避免 Pod 调度到同一节点。
+  如果您有更高的要求，例如避免调度到同一个可用区的节点，实现异地多活，则可以使用 `failure-domain.beta.kubernetes.io/zone`。
+  但通常情况下，同一个集群的节点都在一个地域，如果节点跨地域，即使使用专线，时延也会很大。如果无法避免调度到同一个地域的节点，则可以使用 `failure-domain.beta.kubernetes.io/region`。
+
+## 使用置放群组从物理层面做容灾 <span id="PlacementSet"></span>
+
+在云服务器底层硬件/软件故障的情况下，可能导致多台节点同时异常，这时候我们即便用反亲和性将 Pod 打散到不同节点上，也还是可能造成业务异常。使用 [置放群组](https://cloud.tencent.com/document/product/213/15486) 可以将节点从物理机、交换机或机架三种物理层面其中一种进行打散，以避免底层硬件/软件故障造成节点批量异常。以下是操作步骤:
+
+1. 首先，我们需要在 [置放群组控制台](https://console.cloud.tencent.com/cvm/ps) 创建一个置放群组 (注意地域要选在跟当前集群在同一地域)，根据自己需求从物理机层级、交换机层级和机架层级中选一种作为节点的打散策略。
+2. 批量添加节点，勾选 `将实例添加到分散置放群组` ，选择上一步中所创建的置放群组:
+<img style="width:450px" src="https://main.qcloudimg.com/raw/71f12a028b666fb414ecd73c1fa560cf.png" data-nonescope="true">
+3. 为这一批次的节点打上相同 label 进行标识，这些节点是置放群组中某个同一批次添加的节点:
+<img style="width:450px" src="https://main.qcloudimg.com/raw/276684c8f448e70a366a2981408ac54b.png" data-nonescope="true">
+4. 节点创建好后，给要部署的工作负载的 Pod 指定节点亲和性，指定部署在这一批节点上，同时也指定 Pod 反亲和，将 Pod 在这批节点中尽量打散调度，示例:
+```
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: "placement-set-uniq"
+          operator: In
+          values:
+          - "rack1"
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - nginx
+        topologyKey: kubernetes.io/hostname
+```
+
+> ! 置放群组的策略仅对同一批次的节点生效，所以我们需要为每一批次都打上 label 并且指定不同的值来进行标识。
 
 ## 使用 PodDisruptionBudget 避免驱逐导致服务不可用<span id="PodDisruptionBudget"></span>
 
@@ -145,87 +178,6 @@ spec:
 更多参考资料请前往 Kubernetes 官网 [Container probes](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) 及 [Container Lifecycle Hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/)。
 
 
-## 解决长连接服务扩容失效<span id="lapse"></span>
-
-在现网运营中，有很多场景为了提高效率一般都采用了建立长连接的方式来请求。如果客户端使用长连接请求服务端的方式，Kubernetes 的自动扩容将会失效。其原因是客户端长连接一直保留在之前的 Pod 容器中，未长连接至新扩容的 Pod 容器中，不仅导致 Kubernetes 按照步长扩容第一批 Pod 之后就停止了扩容操作，还导致新扩容的 Pod 未能承载请求，进而出现服务过载的情况，使得自动扩容失去意义。
-
-针对以上问题，我们的解决方法是将长连接转换为短连接。该解决方法参考了 nginx keepalive 的设计，nginx 中 `keepalive_requests` 配置项设定一个 TCP 连接能处理的最大请求数。当该配置项达到设定值时（例如1000），服务端会在 HTTP 的 Header 头标记 `“Connection:close”`，并通知客户端处理完当前的请求后关闭连接，新的请求需要重新建立 TCP 连接。因此，在此过程中不会出现请求失败的情况，同时还达到了将长连接按需转换为短连接的目的。通过此方法，客户端和云 Kubernetes 服务端在处理完一批请求后不断的更新 TCP 连接，而自动扩容的新 Pod 即能接收到新的连接请求，从而解决了自动扩容失效的问题。
-
-由于 Golang 并没有提供方法可以获取到每个连接处理过的请求数，我们重写了 `net.Listener` 和 `net.Conn`，注入请求计数器，对每个连接处理的请求进行计数，并通过 `net.Conn.LocalAddr()` 获得计数值，当判断达到阈值1000后，在返回的 Header 中插入 `“Connection:close”` 通知客户端关闭连接，重新建立连接来发起请求。
-
-以上处理逻辑用 Golang 实现的示例代码如下：
-```
-package main
-
-import (
-    "net"
-    "github.com/gin-gonic/gin"
-    "net/http"
-)
-
-// 重新定义net.Listener
-type counterListener struct {
-    net.Listener
-}
-
-// 重写net.Listener.Accept(),对接收到的连接注入请求计数器
-func (c *counterListener) Accept() (net.Conn, error) {
-    conn, err := c.Listener.Accept()
-    if err != nil {
-        return nil, err
-    }
-    return &counterConn{Conn: conn}, nil
-}
-
-// 定义计数器counter和计数方法Increment()
-type counter int
-
-func (c *counter) Increment() int {
-    *c++
-    return int(*c)
-}
-
-// 重新定义net.Conn,注入计数器ct
-type counterConn struct {
-    net.Conn
-    ct counter
-}
-
-// 重写net.Conn.LocalAddr()，返回本地网络地址的同时返回该连接累计处理过的请求数
-func (c *counterConn) LocalAddr() net.Addr {
-    return &counterAddr{c.Conn.LocalAddr(), &c.ct}
-}
-
-// 定义TCP连接计数器,指向连接累计请求的计数器
-type counterAddr struct {
-    net.Addr
-    *counter
-}
-
-func main() {
-    r := gin.New()
-    r.Use(func(c *gin.Context) {
-        localAddr := c.Request.Context().Value(http.LocalAddrContextKey)
-        if ct, ok := localAddr.(interface{ Increment() int }); ok {
-            if ct.Increment() >= 1000 {
-                c.Header("Connection", "close")
-            }
-        }
-        c.Next()
-    })
-    r.GET("/", func(c *gin.Context) {
-        c.String(200, "plain/text", "hello")
-    })
-    l, err := net.Listen("tcp", ":8080")
-    if err != nil {
-        panic(err)
-    }
-    err = http.Serve(&counterListener{l}, r)
-    if err != nil {
-        panic(err)
-    }
-}
-```
 
 
 


### PR DESCRIPTION
1. 新增 "使用置放群组从物理层面做容灾"
2. 删除 "解决长连接扩容失效"，这个放高可用里不合适，后面放到容器化分类下，整理更全的长连接服务在容器场景下的问题及解决方案。