### PR TITLE
Update 图像安全审核.md

### DIFF
--- a/product/移动与通信/应用服务平台/扩展能力/图像安全审核.md
+++ b/product/移动与通信/应用服务平台/扩展能力/图像安全审核.md
@@ -78,8 +78,8 @@ npm install --save @cloudbase/extension-ci@latest
 
 | 名称       | 类型   | 是否必须 | 说明                                     |
 | ---------- | ------ | -------- | ---------------------------------------- |
-| action     | String | 是       | 操作类型，传：ImageProcess               |
-| cloudPath  | String | 是       | 文件的绝对路径，与 tcb.uploadFile 中一致 |
+| action     | String | 是       | 操作类型，传：DetectType               |
+| cloudPath  | String | 是       | 图片文件的相对路径，可在当前云开发环境中、云存储根目录下查看。 |
 | operations | Object | 是       | 处理参数。                               |
 
 operations 节点内容
@@ -144,7 +144,7 @@ async function demo() {
     };
     const res = await app.invokeExtension("CloudInfinite", {
       action: "DetectType",
-      cloudPath: "ab.png", // 需要分析的图像的绝对路径，与tcb.uploadFile中一致
+      cloudPath: "xxx.png", // 图片文件的相对路径，可在当前云开发环境中、云存储根目录下查看。
       operations: opts
     });
     console.log(JSON.stringify(res.data, null, 4));


### PR DESCRIPTION
根据云函数实际测试发现，只有传入`DetectType`才能够正常跑通。
图片路径不是`cloud://`开头的fileid，而是以云存储为根目录的相对路径。