### PR TITLE
修正 containerd 和 docker 选择错误描述。

### DIFF
--- a/product/计算与网络/容器服务/常见问题/如何选择 Containerd 和 docker.md
+++ b/product/计算与网络/容器服务/常见问题/如何选择 Containerd 和 docker.md
@@ -3,7 +3,7 @@
 
 TKE 支持用户选择 containerd 和 docker 作为运行时组件：
 - Containerd 调用链更短，组件更少，更稳定，占用节点资源更少。 建议选择 containerd。
-- 使用 Containerd 你依然可以用docker in docker 技术在容器中实现 docker build/push/save/load 和 简单的 docker compose 或 docker swarm。
+- 使用 Containerd 你依然可以用 docker in docker 技术在容器中实现 docker build/push/save/load 和 简单的 docker compose 或 docker swarm。
 - 当您遇到以下情况时，请选择 docker 作为运行时组件：
  - 如需在 TKE 节点使用 docker build/push/save/load 等命令。
  - 如需在 TKE 节点使用 docker compose 或 docker swarm。

--- a/product/计算与网络/容器服务/常见问题/如何选择 Containerd 和 docker.md
+++ b/product/计算与网络/容器服务/常见问题/如何选择 Containerd 和 docker.md
@@ -3,11 +3,10 @@
 
 TKE 支持用户选择 containerd 和 docker 作为运行时组件：
 - Containerd 调用链更短，组件更少，更稳定，占用节点资源更少。 建议选择 containerd。
+- 使用 Containerd 你依然可以用docker in docker 技术在容器中实现 docker build/push/save/load 和 简单的 docker compose 或 docker swarm。
 - 当您遇到以下情况时，请选择 docker 作为运行时组件：
- - 如需使用 docker in docker。
  - 如需在 TKE 节点使用 docker build/push/save/load 等命令。
- - 如需调用 docker API。
- - 如需 docker compose 或 docker swarm。
+ - 如需在 TKE 节点使用 docker compose 或 docker swarm。
  
 
 ### Containerd 和 Docker 组件常用命令是什么？


### PR DESCRIPTION
### What changed?

修正关于 containerd 和 docker 选择的错误描述。 docker in docker 技术并不依赖 docker runtime，containerd也可以跑 dind。

### Why?

修改为以下描述，这样才可以让大家放心使用 containerd 而没有后顾之忧。

TKE 支持用户选择 containerd 和 docker 作为运行时组件：
- Containerd 调用链更短，组件更少，更稳定，占用节点资源更少。 建议选择 containerd。
- 使用 Containerd 你依然可以用 docker in docker 技术在容器中实现 docker build/push/save/load 和 简单的 docker compose 或 docker swarm。
- 当您遇到以下情况时，请选择 docker 作为运行时组件：
   - 如需在 TKE 节点使用 docker build/push/save/load 等命令。
   - 如需在 TKE 节点使用 docker compose 或 docker swarm。

### Before?

TKE 支持用户选择 containerd 和 docker 作为运行时组件：

Containerd 调用链更短，组件更少，更稳定，占用节点资源更少。 建议选择 containerd。
当您遇到以下情况时，请选择 docker 作为运行时组件：
- 如需使用 docker in docker。
-  如需在 TKE 节点使用 docker build/push/save/load 等命令。
- 如需调用 docker API。
- 如需 docker compose 或 docker swarm。

### How did you prove it?
新建一个 containerd 集群。执行：
```
kubectrl apply -f https://raw.githubusercontent.com/ti/server/master/httpserver/deployment.yaml
```

