### PR TITLE
修复TRTC集成文档中“全平台（C++）API 概览”超链接错误的问题

### DIFF
--- a/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Android).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Android).md
@@ -172,4 +172,4 @@ using namespace trtc;
 
 >?
 >- 配置 Android Studio C/C++ 开发环境具体可以参考 Android Studio 官方文档：[向 Android 项目添加 C 和 C++ 代码](https://developer.android.com/studio/projects/add-native-code) 。 
->- 目前只有 TRTC 版本的 SDK 支持 C++ 接口；对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32689#TRTC)。
+>- 目前只有 TRTC 版本的 SDK 支持 C++ 接口；对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32268)。

--- a/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(iOS).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(iOS).md
@@ -107,7 +107,7 @@ TRTC SDK 支持两种调用方式，您可以任选一种
 using namespace trtc;
 ```
 
->? 对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32689#TRTC)。
+>? 对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32268)。
 
 ## 常见问题
 ### 1. TRTC SDK 是否支持后台运行？

--- a/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(mac).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(mac).md
@@ -106,4 +106,4 @@ TRTC SDK 支持两种调用方式，您可以任选一种
 using namespace trtc;
 ```
 
->? 对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32689#TRTC)。
+>? 对于 C++ 接口的使用方式，请参见 [全平台（C++）API 概览](https://cloud.tencent.com/document/product/647/32268)。


### PR DESCRIPTION
修复TRTC集成文档中“全平台（C++）API 概览”超链接错误的问题