### PR TITLE
Update `tdmq-client` JDK version

### DIFF
--- a/product/互联网中间件/分布式消息队列/SDK 文档/Java SDK下载方式.md
+++ b/product/互联网中间件/分布式消息队列/SDK 文档/Java SDK下载方式.md
@@ -150,7 +150,7 @@ mvn help:effective-settings 。
     <dependency>
     		<groupId>com.tencent.tdmq</groupId>
     		<artifactId>tdmq-client</artifactId>
-    		<version>2.6.0</version>
+    		<version>2.5.0</version>
     </dependency>
 ``` 
 2. 在 pom.xml 所在目录执行 `mvn clean package` 即可下载 TDMQ SDK。


### PR DESCRIPTION
After confirmation, there is currently no version 2.6.0 of `tdmq-client`. The wrong version may be written in the official document. Maybe we need to change the version information from 2.6.0 to 2.5.0.