### PR TITLE
更改

### DIFF
--- a/product/计算与网络/Serverless Framework/最佳实践/部署全景录制.md
+++ b/product/计算与网络/Serverless Framework/最佳实践/部署全景录制.md
@@ -139,7 +139,7 @@ Content-Type: application/json
 | Width           | number | 否   | 录制画面宽度，默认为1280，合法取值范围[0, 2560]            |
 | Height          | number | 否   | 录制画面高度，默认为720，合法取值范围[0, 2560]             |
 | CallbackURL     | string | 否   | 录制结果通知回调地址                                         |
-| MaxDurationLimi | int    | 否   | 录制最大时长限制， 单位s, 合法取值范围[0, 36000]，默认21600s（6小时），超过6小时需要配置永久密钥 |
+| MaxDurationLimit | int    | 否   | 录制最大时长限制， 单位s, 合法取值范围[0, 36000]，默认21600s（6小时），超过6小时需要配置永久密钥 |
 | Cos             | object | 是   | 请求协议参数                                                 |
 | Domain          | string | 否   | 录制文件回放域名，不设置为默认源站域名                       |
 | Bucket          | string | 否   | 录制文件存放空间，不设置默认为创建函数时设置的存储空间       |
@@ -216,7 +216,7 @@ Content-Type: application/json
 ::: 请求Body参数说明
 | 参数        | 类型   | 必填 | 说明                                                         |
 | ----------- | ------ | ---- | ------------------------------------------------------------ |
-| Action      | string | 是   | 请求操作类型，结束录制为 `Pause`                             |
+| Action      | string | 是   | 请求操作类型，暂停录制为 `Pause`                             |
 | Data        | object | 是   | 请求协议参数                                                 |
 | Data.TaskID | string | 是   | 需要暂停录制的录制任务 ID，录制任务 ID 可以在开始录制的接口返回参数中获取到 |
 :::
@@ -270,7 +270,7 @@ Content-Type: application/json
 
 | 参数        | 类型   | 必填 | 说明                                                         |
 | ----------- | ------ | ---- | ------------------------------------------------------------ |
-| Action      | string | 是   | 请求操作类型，结束录制为 `Resume`                            |
+| Action      | string | 是   | 请求操作类型，恢复暂停录制为 `Resume`                            |
 | Data        | object | 是   | 请求协议参数                                                 |
 | Data.TaskID | string | 是   | 需要恢复录制的录制任务 ID，录制任务 ID 可以在开始录制的接口返回参数中获取到 |
 :::


### PR DESCRIPTION
 1、| Action      | string | 是   | 请求操作类型，恢复暂停录制为 `Resume`    
  2、| Action      | string | 是   | 请求操作类型，暂停录制为 `Pause`  
 3、| MaxDurationLimit | int    | 否   | 录制最大时长限制， 单位s, 合法取值范围[0, 36000]，默认21600s（6小时），超过6小时需要配置永久密钥 |