### PR TITLE
Update 连接集群.md

### DIFF
--- a/product/计算与网络/容器服务/控制台指南（新版）/集群管理/连接集群.md
+++ b/product/计算与网络/容器服务/控制台指南（新版）/集群管理/连接集群.md
@@ -4,22 +4,21 @@
 ## 前提条件
 请安装 curl 软件。
 请根据操作系统的类型，选择获取 Kubectl 工具的方式：
->? 根据实际需求，将命令行中的 “v1.8.13” 替换成业务所需的 Kubectl 版本。
 
 - **Mac OS X 系统**
 执行以下命令，获取 Kubectl 工具：
 ```shell
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.13/bin/darwin/amd64/kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/amd64/kubectl"
 ```
 - **Linux 系统**
 执行以下命令，获取 Kubectl 工具：
 ```shell
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.13/bin/linux/amd64/kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 ```
 - **Windows 系统**
 执行以下命令，获取 Kubectl 工具：
 ```shell
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.13/bin/windows/amd64/kubectl.exe
+curl -LO https://dl.k8s.io/release//bin/windows/amd64/kubectl.exe
 ```
 
 ## 操作步骤


### PR DESCRIPTION
官网目前下载的kubectl工具版本1.8.13太低，用户直接使用这个地址安装到机器上面连接集群会有问题
避免每次更新文档版本内容，直接改成kubernetes官网命令下载stable的最新版本：https://kubernetes.io/docs/tasks/tools/