### PR TITLE
Update: 优图速算题目批改/SDK 文档/Android SDK.md

### DIFF
--- a/product/教育/优图速算题目批改/SDK 文档/Android SDK.md
+++ b/product/教育/优图速算题目批改/SDK 文档/Android SDK.md
@@ -13,7 +13,7 @@ TAISDK 是一款封装了腾讯云教育 AI 能力的 SDK，通过集成 SDK，�
 ### 1. 导入 SDK
 下载 [Demo 源码](https://github.com/TencentCloud/tencentcloud-sdk-android-soe)，并在 build.gradle 引入依赖包。
 ```java
-implementation 'com.tencent.taisdk:taisdk:1.2.0.61'
+implementation 'com.tencent.taisdk:taisdk:+'
 ```
 
 ### 2. 调用接口
@@ -34,6 +34,8 @@ param.imageData = outputStream.toByteArray();
 
 param.secretId = "";
 param.secretKey = "";
+// 如果使用服务端生成临时secretKey，需要同时传入token
+param.token = "";
 //作业批改
 this.correction.correction(param, new TAIMathCorrectionCallback() {
     @Override


### PR DESCRIPTION
按照原版文档集成，其固定的sdk版本号中参数缺少token导致临时token无法注入sdk产生报错，故完善文档以下内容
1. 更新SDK版本号为使用最新版本
2. 添加追加的token参数说明