### PR TITLE
文档中添加auth结果详情及错误码说明

### DIFF
--- a/product/视频服务/美视优享/SDK集成指引/一分钟集成TRTC/Android.md
+++ b/product/视频服务/美视优享/SDK集成指引/一分钟集成TRTC/Android.md
@@ -64,6 +64,12 @@ private synchronized void checkAuth(Context context) {
 }
 ```
 
+4. 如果鉴权失败，你可以
+
+   [查看鉴权结果及错误码详情]: 
+
+   ，以定位失败原因。
+
 [](id:step3)
 
 ## 步骤三：打开 app 模块的 build.gradle

--- a/product/视频服务/美视优享/SDK集成指引/一分钟集成直播/Android.md
+++ b/product/视频服务/美视优享/SDK集成指引/一分钟集成直播/Android.md
@@ -62,6 +62,12 @@ private synchronized void checkAuth(Context context) {
 }
 ```
 
+4. 如果鉴权失败，你可以
+
+   [查看鉴权结果及错误码详情]: 
+
+   ，以定位失败原因。
+
 [](id:step3)
 ## 步骤三：打开 app 模块的 build.gradle
 1. 将 applicationId 修改成与申请的测试授权⼀致的包名。

--- a/product/视频服务/美视优享/SDK集成指引/一分钟集成短视频/Android.md
+++ b/product/视频服务/美视优享/SDK集成指引/一分钟集成短视频/Android.md
@@ -64,6 +64,12 @@ private synchronized void checkAuth(Context context) {
 }
 ```
 
+4. 如果鉴权失败，你可以
+
+[查看鉴权结果及错误码详情]: 
+
+，以定位失败原因。
+
 [](id:step3)
 ## 步骤三：打开 app 模块的 build.gradle
 1. 将 applicationId 修改成与申请的测试授权⼀致的包名。

--- a/product/视频服务/美视优享/SDK集成指引/一分钟集成腾讯特效/Android.md
+++ b/product/视频服务/美视优享/SDK集成指引/一分钟集成腾讯特效/Android.md
@@ -106,6 +106,12 @@ private synchronized void checkAuth(Context context) {
 }
 ```
 
+4. 如果鉴权失败，你可以
+
+[查看鉴权结果及错误码详情]: 
+
+，以定位失败原因。
+
 [](id:step2)
 ### 步骤二：加载腾讯特效 SDK xmagic-xxx.aar
 使用腾讯特效 SDK 生命周期大致如下：

--- a/product/视频服务/美视优享/SDK集成指引/鉴权结果及错误码说明/Android.md
+++ b/product/视频服务/美视优享/SDK集成指引/鉴权结果及错误码说明/Android.md
@@ -1,0 +1,47 @@
+ # Auth.AuthResult  授权返回结果实体类
+
+ - public final boolean isSucceed;
+   
+    >是否授权成功
+- public final AuthResultSucceed authResultSucceed;
+  
+    >授权成功详情
+- public final AuthResultFail authResultFail;
+  
+    >授权失败详情
+- public final AuthInfo authInfo;
+  
+    >授权详情信息, 一般供排查问题时使用
+
+# Auth.AuthResultSucceed 授权成功详情实体类
+
+- public final Map<Integer, String> features = new HashMap<Integer, String>();
+  
+    >已授权的能力 <能力ID, 能力名称> 
+- public final long endTime;
+  
+    >授权结束时间, UNIX 时间戳, 单位是秒
+- public final String endTimeStr;
+  
+    >授权结束时间格式化后的字符串, 方便阅读
+
+
+# Auth.AuthResultFail 授权失败详情实体类
+
+- public final int code;
+  
+    >错误码
+- public final String msg;
+  
+    >错误提示信息
+
+
+# 错误码
+如果ret授权返回0，则已授权成功。否则请按照返回值来排查问题：
+|错误码    |原因 |处理建议|
+|--------|:---:|:----:|
+|3004/3005 |无效授权 | 检查授权文件的文件名/路径是否正确，比如license和licence的拼写方式是否统一|
+|3015 |bundle id / package name不匹配 | 检查您的APP使用的bundle id / package name和申请的是否一致，检查是否使用了正确的授权文件|
+|3018 |授权文件已过期 | 需要向腾讯云申请续期 |
+|其他 |内部错误 | 请将错误码上报给腾讯云支持团队处理 |
+


### PR DESCRIPTION
注：“查看鉴权结果及错误码详情” 这里需要添加一个跳转链接，跳去 SDK集成指引/鉴权结果及错误码说明/Android.md 这个文档