### PR TITLE
update 所有文档中 TRTC Electron 开源代码库的地址，涉及9篇文档

### DIFF
--- a/product/移动与通信/即时通信/最佳实践/微信 H5 直播互动.md
+++ b/product/移动与通信/即时通信/最佳实践/微信 H5 直播互动.md
@@ -112,7 +112,7 @@ tweblive.enterRoom(<span class="hljs-string">""</span>); <span class="hljs-comme
 - 在支持 MSE 的浏览器上，直播组件会优先选择使用 flv 直播源，延时更低，直播效果更好。
 - 在不支持 MSE 的浏览器上，直播组件会使用 hls 直播源，延时稍大，但在移动端适应性好。
 
-如果在 Windows 或 Mac 平台推直播流，强烈建议使用 [TRTC Electron](https://github.com/tencentyun/TRTCSDK/tree/master/Electron)，**旁路推流可同时生成 flv 和 hls 流，与即时通信 IM 完美结合，稳定可靠，服务周到**。
+如果在 Windows 或 Mac 平台推直播流，强烈建议使用 [TRTC Electron](https://github.com/LiteAVSDK/TRTC_Electron)，**旁路推流可同时生成 flv 和 hls 流，与即时通信 IM 完美结合，稳定可靠，服务周到**。
 快速实现直播和旁路推流的操作步骤请参见 [跑通 Electron Demo](https://cloud.tencent.com/document/product/647/38548)。
 ![](https://demovideo-1252463788.cos.ap-shanghai.myqcloud.com/electron/electron.gif)
 

--- a/product/视频服务/实时音视频/代码示例.md
+++ b/product/视频服务/实时音视频/代码示例.md
@@ -116,7 +116,7 @@
             </div>
         </div>
     </a>
-    <a href="https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTC-API-Example" target="view_window">
+    <a href="https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTC-API-Example" target="view_window">
         <div class="card-container">
             <div class="card">
                 <img src="https://main.qcloudimg.com/raw/559e93ed3c05c3916300b04b0b09e7aa.svg" data-nonescope="true">

--- a/product/视频服务/实时音视频/客户端 API/Electron/Electron API 概览.md
+++ b/product/视频服务/实时音视频/客户端 API/Electron/Electron API 概览.md
@@ -3,7 +3,7 @@
 腾讯云视频通话功能的主要接口类。
 
 - **主要文档地址**：[TRTC Electron SDK](https://web.sdk.qcloud.com/trtc/electron/doc/zh-cn/trtc_electron_sdk/index.html)
-- **示例代码地址**：[TRTC Electron Demo](https://github.com/tencentyun/TRTCSDK/tree/master/Electron)
+- **示例代码地址**：[TRTC Electron Demo](https://github.com/LiteAVSDK/TRTC_Electron)
 
 ### 创建 TRTC 对象
 ```js

--- a/product/视频服务/实时音视频/快速入门/一分钟跑通DEMO/跑通Demo(Electron).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟跑通DEMO/跑通Demo(Electron).md
@@ -161,6 +161,6 @@ TRTC SDK 6.6 版本（2019年08月）开始启用新的签名算法 HMAC-SHA256�
 
 - [SDK API 手册](https://web.sdk.qcloud.com/trtc/electron/doc/zh-cn/trtc_electron_sdk/index.html)
 - [SDK 更新日志](https://cloud.tencent.com/document/product/647/43117)
-- [Simple Demo 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTCSimpleDemo)
-- [API Example 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTC-API-Example)
+- [Simple Demo 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTCSimpleDemo)
+- [API Example 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTC-API-Example)
 - [Electron 常见问题](https://cloud.tencent.com/document/product/647/62562)

--- a/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Electron).md
+++ b/product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Electron).md
@@ -254,6 +254,6 @@ $ npm run pack:win64
 
 - [SDK API 手册](https://web.sdk.qcloud.com/trtc/electron/doc/zh-cn/trtc_electron_sdk/index.html)
 - [SDK 更新日志](https://cloud.tencent.com/document/product/647/43117)
-- [Simple Demo 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTCSimpleDemo)
-- [API Example 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTC-API-Example)
+- [Simple Demo 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTCSimpleDemo)
+- [API Example 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTC-API-Example)
 - [Electron 常见问题](https://cloud.tencent.com/document/product/647/62562)

--- a/product/视频服务/实时音视频/最佳实践/跑通直播模式/跑通直播模式（Electron）.md
+++ b/product/视频服务/实时音视频/最佳实践/跑通直播模式/跑通直播模式（Electron）.md
@@ -18,7 +18,7 @@ TRTC 云服务由两种不同类型的服务器节点组成，分别是“接口
 
 ## 示例代码
 
-您可以登录 [Github](https://github.com/tencentyun/TRTCSDK/tree/master/Electron) 获取本文档相关的示例代码。
+您可以登录 [Github](https://github.com/LiteAVSDK/TRTC_Electron) 获取本文档相关的示例代码。
 
 ## 操作步骤
 

--- a/product/视频服务/实时音视频/最佳实践/跑通通话模式/跑通通话模式（Electron）.md
+++ b/product/视频服务/实时音视频/最佳实践/跑通通话模式/跑通通话模式（Electron）.md
@@ -18,7 +18,7 @@ TRTC 云服务由两种不同类型的服务器节点组成，分别是“接口
 
 ## 示例代码
 
-您可以登录 [Github](https://github.com/tencentyun/TRTCSDK/tree/master/Electron) 获取本文档相关的示例代码。
+您可以登录 [Github](https://github.com/LiteAVSDK/TRTC_Electron) 获取本文档相关的示例代码。
 
 ## 操作步骤
 

--- a/product/视频服务/实时音视频/解决方案/实时互动课堂/实时互动课堂(Electron).md
+++ b/product/视频服务/实时音视频/解决方案/实时互动课堂/实时互动课堂(Electron).md
@@ -106,6 +106,6 @@ yarn package
 
 - [SDK API 手册](https://web.sdk.qcloud.com/trtc/electron/doc/zh-cn/trtc_electron_sdk/index.html)
 - [SDK 更新日志](https://cloud.tencent.com/document/product/647/43117)
-- [Simple Demo 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTCSimpleDemo)
-- [API Example 源码](https://github.com/tencentyun/TRTCSDK/tree/master/Electron/TRTC-API-Example)
+- [Simple Demo 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTCSimpleDemo)
+- [API Example 源码](https://github.com/LiteAVSDK/TRTC_Electron/tree/main/TRTC-API-Example)
 - [Electron 常见问题](https://cloud.tencent.com/document/product/647/62562)

--- a/product/视频服务/视立方·音视频终端引擎/7-操作实践/实时互动/多人通话/Electron.md
+++ b/product/视频服务/视立方·音视频终端引擎/7-操作实践/实时互动/多人通话/Electron.md
@@ -18,7 +18,7 @@
 
 ## 示例代码
 
-您可以登录 [Github](https://github.com/tencentyun/TRTCSDK/tree/master/Electron) 获取本文档相关的示例代码。
+您可以登录 [Github](https://github.com/LiteAVSDK/TRTC_Electron) 获取本文档相关的示例代码。
 
 ## 操作步骤
 


### PR DESCRIPTION
1、“product/移动与通信/即时通信/最佳实践/微信 H5 直播互动.md” 更新 “步骤3:提供直播源” 部分跳转 TRTC Electron 开源代码库的超链接。 未找到在线链接地址，未发布页面。
2、“product/视频服务/实时音视频/代码示例.md” 更新 “API 示例” 部分 “Electron API 示例” 跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/57486
3、“product/视频服务/实时音视频/客户端 API/Electron/Electron API 概览.md” 更新 “示例代码地址：TRTC Electron Demo” 跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/38551
4、“product/视频服务/实时音视频/快速入门/一分钟跑通DEMO/跑通Demo(Electron).md” 更新 “参考文档”部分，跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/38548
5、“product/视频服务/实时音视频/快速入门/一分钟集成SDK/快速集成(Electron).md“ 更新 “参考文档”部分，跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/38549
6、“product/视频服务/实时音视频/最佳实践/跑通直播模式/跑通直播模式（Electron）.md“ 更新 ”示例代码“ 部分跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/43771
7、“product/视频服务/实时音视频/最佳实践/跑通通话模式/跑通通话模式（Electron）.md” 更新 ”示例代码“ 部分跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/43770
8、“product/视频服务/实时音视频/解决方案/实时互动课堂/实时互动课堂(Electron).md“ 更新 “参考文档”部分，跳转 TRTC Electron 开源代码库的超链接。
https://cloud.tencent.com/document/product/647/45465
9、“product/视频服务/视立方·音视频终端引擎/7-操作实践/实时互动/多人通话/Electron.md” 更新  ”示例代码“ 部分跳转 TRTC Electron 开源代码库的超链接。未找到在线链接地址，未发布页面。