### PR TITLE
Update 生成预签名URL.md

### DIFF
--- a/product/存储与CDN/对象存储 4.0/SDK文档/Java SDK/对象操作/生成预签名URL.md
+++ b/product/存储与CDN/对象存储 4.0/SDK文档/Java SDK/对象操作/生成预签名URL.md
@@ -293,6 +293,7 @@ COSCredentials cred = new BasicCOSCredentials(secretId, secretKey);
 String bucketName = "examplebucket-1250000000";
 // 对象键(Key)是对象在存储桶中的唯一标识。详情请参见 [对象键](https://cloud.tencent.com/document/product/436/13324)
 String key = "exampleobject";
+String resource_path="/" + key
 
 ClientConfig clientConfig = new ClientConfig(new Region("ap-beijing-1"));
 
@@ -315,5 +316,5 @@ headers.put("header1", "value1");
 // 请求的 HTTP 方法，上传请求用 PUT，下载请求用 GET，删除请求用 DELETE
 HttpMethodName method = HttpMethodName.GET;
 
-String sign = signer.buildAuthorizationStr(method, key, headers, params, cred, expirationDate, true);
+String sign = signer.buildAuthorizationStr(method, resource_path, headers, params, cred, expirationDate, true);
 ```


### PR DESCRIPTION
signer.buildAuthorizationStr 的 第二个参数 资源路径 要在对象key前面加斜杠。我说怎么试了半天签名一直被拒绝...
![image](https://user-images.githubusercontent.com/66937093/158000602-78efdaa8-ded8-415d-a739-c38435a9ce1e.png)
