### PR TITLE
fix: 限制上传文件大小和类型.md

### DIFF
--- a/product/存储与CDN/对象存储 4.0/最佳实践/数据安全/限制上传文件大小.md
+++ b/product/存储与CDN/对象存储 4.0/最佳实践/数据安全/限制上传文件大小.md
@@ -108,18 +108,20 @@ x-cos-request-id: NTk5ZDM5N2RfMjNiMjM1MGFfMmRiX2Y0****
 
 案例一的优点是使用简单，只需要在请求表单里添加一个参数即可实现。但缺点是只支持 POST Object 接口，不支持 PUT Object 接口；不利于统一管理，请求执行者可以在生成请求时修改限制参数，导致可上传限制范围之外的对象大小。
 
-存储桶的管理人员可以在申请临时密钥时，使用以下字段来限制对象大小，COS 对象大小使用字段 cos:content_length 来表示：
+存储桶的管理人员可以在申请临时密钥时，使用以下字段来限制对象大小，COS 对象大小使用字段 cos:content-length 来表示：
 
 | 条件字段                   | 含义         | 示例                                                         |
 | -------------------------- | ------------ | ------------------------------------------------------------ |
-| numeric_greater_than       | 数值大于     | {"numeric_greater_than": {"cos:content_length": 1}}，对象必须大于1byte |
-| numeric_greater_than_equal | 数值大于等于 | {"numeric_greater_than_equal": {"cos:content_length": 1}}，对象必须大于或者等于1byte |
-| numeric_less_than          | 数值小于     | {"numeric_less_than": {"cos:content_length": 1}}，对象必须小于1byte |
-| numeric_less_than_equal    | 数值小于等于 | {"numeric_less_than_equal": {"cos:content_length": 1}}，对象必须小于或者等于1byte |
+| numeric_greater_than       | 数值大于     | {"numeric_greater_than": {"cos:content-length": 1}}，对象必须大于1byte |
+| numeric_greater_than_equal | 数值大于等于 | {"numeric_greater_than_equal": {"cos:content-length": 1}}，对象必须大于或者等于1byte |
+| numeric_less_than          | 数值小于     | {"numeric_less_than": {"cos:content-length": 1}}，对象必须小于1byte |
+| numeric_less_than_equal    | 数值小于等于 | {"numeric_less_than_equal": {"cos:content-length": 1}}，对象必须小于或者等于1byte |
+
+有关对象存储的更多字段可参考 [条件键说明及使用示例](https://cloud.tencent.com/document/product/436/71307) 文档。
 
 完整请求可参考 [STS 的获取临时访问凭证](https://cloud.tencent.com/document/product/1312/48195) API 文档，一个完整的策略（policy）如下：
 
-```plaintext
+```json
 {
     "version": "2.0",
     "statement": [
@@ -134,8 +136,12 @@ x-cos-request-id: NTk5ZDM5N2RfMjNiMjM1MGFfMmRiX2Y0****
             ],
 
             "condition": {
-                "numeric_greater_than_equal": {"cos:content_length": 1}
-                , "numeric_less_than": {"cos:content_length": 10}
+                "numeric_greater_than_equal": {
+                   "cos:content-length": 1
+                }, 
+                "numeric_less_than": {
+                   "cos:content-length": 10
+                }
             }
         }
     ]
@@ -161,6 +167,16 @@ Connection: keep-alive
 Date: Wed, 23 Aug 2020 08:14:53 GMT
 Server: tencent-cos
 x-cos-request-id: NTk5ZDM5N2RfMjNiMjM1MGFfMmRiX2Y0****
+
+<?xml version='1.0' encoding='utf-8' ?>
+<Error>
+        <Code>AccessDenied</Code>
+        <Message>Access Denied.</Message>
+        <ServerTime>***</ServerTime>
+        <Resource>***</Resource>
+        <RequestId>NjM3ZTEzNDh***</RequestId>
+        <TraceId>OGVmYzZiMmQzYj***</TraceId>
+</Error>
 ```
 
 ## 案例三：通过存储桶策略限制文件上传类型


### PR DESCRIPTION
案例二的`cos:content_length`字段是错的！中间不是下划线，就是一个正常的短横线：`cos:content-length`。

这里的是对的[条件键说明及使用示例](https://cloud.tencent.com/document/product/436/71307)，昨天试了一晚上结果发现是文档写错了（